### PR TITLE
Mot clé value et accord féminin

### DIFF
--- a/postgresql/queries.xml
+++ b/postgresql/queries.xml
@@ -1103,7 +1103,7 @@ SELECT ... FROM fdt WHERE EXISTS (SELECT c1 FROM t2 WHERE c2 &gt; fdt.c1)</progr
    <indexterm><primary>dépendance fonctionnel</primary></indexterm>
 
    <para>
-    Si la table produits est configuré de façon à ce que
+    Si la table produits est configurée de façon à ce que
     <literal>id_produit</literal> soit la clé primaire, alors il serait suffisant
     de grouper par la colonne <literal>id_produit</literal> dans l'exemple
     ci-dessus, car le nom et le prix seraient <firstterm>dépendants
@@ -1516,11 +1516,11 @@ aussi être donné comme dans&nbsp;:
     guillemets. Par exemple, <literal>VALUE</literal> est un mot clé, ce qui
     fait que ceci ne fonctionne pas&nbsp;:
 <programlisting>
-SELECT a valeur, b + c AS somme FROM ...
+SELECT a value, b + c AS somme FROM ...
      </programlisting>
      mais ceci fonctionne&nbsp;:
      <programlisting>
-SELECT a "valeur", b + c AS somme FROM ...
+SELECT a "value", b + c AS somme FROM ...
      </programlisting>
      Pour vous protéger de possibles ajouts futurs de mots clés, il est recommandé
      de toujours écrire <literal>AS</literal> ou de mettre le nom de colonne de


### PR DESCRIPTION
Le mot clé "value" ne doit pas être traduit dans les deux exemples des requêtes.